### PR TITLE
use hourFee for all transactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -823,8 +823,8 @@
           "https://mempool.space/api/v1/fees/recommended"
         );
         fees = JSON.parse( fees );
-        if (!("minimumFee" in fees)) return "error -- site down";
-        var minfee = fees["minimumFee"];
+        if (!("hourFee" in fees)) return "error -- site down";
+        var minfee = fees["hourFee"];
         return minfee;
       }
       function showModal( content ) {

--- a/index.js
+++ b/index.js
@@ -97,8 +97,8 @@ function postData( url, json, headers ) {
 
 async function getMinFeeRate() {
 	var fees = await getData( "https://mempool.space/api/v1/fees/recommended" );
-	if ( !( "minimumFee" in fees ) ) return "error -- site down";
-	var minfee = fees[ "minimumFee" ];
+	if ( !( "hourFee" in fees ) ) return "error -- site down";
+	var minfee = fees[ "hourFee" ];
 	return minfee;
 }
 

--- a/testnet.html
+++ b/testnet.html
@@ -823,8 +823,8 @@
           "https://mempool.space/testnet/api/v1/fees/recommended"
         );
         fees = JSON.parse( fees );
-        if (!("minimumFee" in fees)) return "error -- site down";
-        var minfee = fees["minimumFee"];
+        if (!("hourFee" in fees)) return "error -- site down";
+        var minfee = fees["hourFee"];
         return minfee;
       }
       function showModal( content ) {

--- a/testnet.js
+++ b/testnet.js
@@ -97,8 +97,8 @@ function postData( url, json, headers ) {
 
 async function getMinFeeRate() {
 	var fees = await getData( "https://mempool.space/testnet/api/v1/fees/recommended" );
-	if ( !( "minimumFee" in fees ) ) return "error -- site down";
-	var minfee = fees[ "minimumFee" ];
+	if ( !( "hourFee" in fees ) ) return "error -- site down";
+	var minfee = fees[ "hourFee" ];
 	return minfee;
 }
 


### PR DESCRIPTION
The mempool.space API returns 5 types of fee estimation values:
```
curl https://mempool.space/api/v1/fees/recommended
{"fastestFee":44,"halfHourFee":39,"hourFee":35,"economyFee":8,"minimumFee":4}
```
The currently used minimumFee is only enough to not get purged from the mempools with default settings and results in transactions stuck for days.
Proposing to use the hourFee instead which is the estimate to aim for a confirmation within the next 3 blocks. This would be a more realistic timeline but still tries to save some without increasing the complexity of the order flow.

See my comment also on: https://stacker.news/items/171335