### PR TITLE
Update Usage of bitcoinjs.crypto.sha256 to Accommodate API Change in bitcoinjs-lib

### DIFF
--- a/index.js
+++ b/index.js
@@ -1249,7 +1249,8 @@ async function getSignedEvent(event, privateKey) {
         event['tags'], // Tags identify replies/recipients
         event['content'], // Your note contents
     ]);
-    event.id = bitcoinjs.crypto.sha256(eventData).toString('hex');
+    const eventDataBuffer = Buffer.from(eventData);
+    event.id = bitcoinjs.crypto.sha256(eventDataBuffer).toString('hex');
     event.sig = await nobleSecp256k1.schnorr.sign(event.id, privateKey);
     return event;
 }

--- a/testnet.js
+++ b/testnet.js
@@ -1248,7 +1248,8 @@ async function getSignedEvent(event, privateKey) {
         event['tags'], // Tags identify replies/recipients
         event['content'], // Your note contents
     ]);
-    event.id = bitcoinjs.crypto.sha256(eventData).toString('hex');
+    const eventDataBuffer = Buffer.from(eventData);
+    event.id = bitcoinjs.crypto.sha256(eventDataBuffer).toString('hex');
     event.sig = await nobleSecp256k1.schnorr.sign(event.id, privateKey);
     return event;
 }


### PR DESCRIPTION
**Summary**
This pull request updates the usage of the bitcoinjs.crypto.sha256 function in Swap-Service getSignedEvent to align with the latest API changes in bitcoinjs-lib. The bitcoinjs-lib has altered the expected input type for bitcoinjs.crypto.sha256, leading to issues when a string is passed instead of a Buffer.

**Background**
An issue was identified where the behavior of the bitcoinjs.crypto.sha256 function in bitcoinjs-lib has changed. As documented in [bitcoinjs-lib issue #2015](https://github.com/bitcoinjs/bitcoinjs-lib/issues/2015), the function now expects a Buffer.
The changed happend in bitcoinjs-lib 6.1
The previous implementation in our library, which passed a string to this function, resulted in incorrect outputs.

**Changes**
Modified getSignedEvent function to to use Buffer.from before sending eventData (string) to bitcoinjs.crypto.sha256.

This change should work with the latest version if bitcoinjs-lib as well as with older versions.

